### PR TITLE
Seperate Gradle build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
 script: ./gradlew test
 jdk: oraclejdk8
+cache: 
+  directories: 
+    - $HOME/.m2

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,16 @@
 group 'github.PtrTeixeira'
 version '0.1.0'
 
+apply from: "gradle/style.gradle"
+apply from: "gradle/uitest.gradle"
+
 def versions = [
-   checkstyle: '6.19',
    jsoup: '1.9.2',
    junit: '4.12',
    log4j: '2.6',
-   testfx: '4.0.4-alpha'
+   hamcrest: '1.3'
 ]
 
-configurations {
-  checkstyleConfig
-}
 
 // Base plugin
 apply plugin: 'java'
@@ -21,48 +20,11 @@ sourceCompatibility = 1.8
 apply plugin: 'project-report'
 apply plugin: 'build-dashboard'
 
-apply plugin: 'checkstyle'
-checkstyle {
-    toolVersion = "${versions.checkstyle}"
-}
-tasks.withType(Checkstyle) {
-  config = resources.text.fromArchiveEntry(configurations.checkstyleConfig, 'google_checks.xml')
-  reports {
-    html.destination rootProject.file("build/reports/checkstyle.html")
+tasks.withType(Test) {
+  testLogging {
+    events "passed", "skipped", "failed"
   }
 }
-
-sourceSets {
-  uiTest {
-    java {
-      compileClasspath += sourceSets.main.output
-      runtimeClasspath += sourceSets.main.output
-    }
-  }
-}
-
-configurations {
-  uiTestCompile.extendsFrom testCompile
-  uiTestRuntime.extendsFrom testRuntime
-}
-
-task uiTest(type: Test) {
-  testClassesDir = sourceSets.uiTest.output.classesDir
-  classpath = sourceSets.uiTest.runtimeClasspath
-  outputs.upToDateWhen { false }
-  jvmArgs(
-     '-Dtestfx.robot=glass',
-     '-Dglass.platform=Monocle',
-     '-Dmonocle.platform=Headless',
-     '-Dprism.order=sw'
-  )
-  onlyIf { project.hasProperty('uiTest') }
-  mustRunAfter test
-}
-check.dependsOn uiTest
-
-uiTest.enabled = false
-
 
 tasks.withType(Test) {
   reports.html.destination = file("${reporting.baseDir}/${name}")
@@ -77,13 +39,5 @@ dependencies {
   compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${versions.log4j}"
 
   testCompile group: 'junit', name: 'junit', version: "${versions.junit}"
-
-  checkstyleConfig module(group: 'com.puppycrawl.tools', name: 'checkstyle', version: "${versions.checkstyle}") {
-    transitive = false
-  }
-
-//  uiTestCompile sourceSets.main.output
-//  uiTestCompile configurations.testCompile
-  testCompile group: 'org.testfx', name: 'testfx-core', version: "${versions.testfx}"
-  testCompile group: 'org.testfx', name: 'testfx-junit', version: "${versions.testfx}"
+  testCompile group: 'org.hamcrest', name: "hamcrest-all", version: "${versions.hamcrest}"
 }

--- a/gradle/style.gradle
+++ b/gradle/style.gradle
@@ -1,0 +1,28 @@
+apply plugin: "checkstyle"
+
+def version = "7.0"
+
+repositories {
+  mavenCentral()
+}
+
+checkstyle {
+  toolVersion = "${version}"
+}
+
+configurations {
+  checkstyleConfig
+}
+
+tasks.withType(Checkstyle) {
+  config = resources.text.fromArchiveEntry(configurations.checkstyleConfig, 'google_checks.xml')
+  reports {
+    html.destination rootProject.file("build/reports/style.html")
+  }
+}
+
+dependencies {
+  checkstyleConfig module(group: 'com.puppycrawl.tools', name: 'checkstyle', version: "${version}") {
+    transitive = false
+  }
+}

--- a/gradle/uitest.gradle
+++ b/gradle/uitest.gradle
@@ -1,0 +1,35 @@
+def version = '4.0.4-alpha'
+
+apply plugin: 'java'
+
+configurations {
+  uiTestCompile.extendsFrom testCompile
+  uiTestRuntime.extendsFrom testRuntime
+}
+
+sourceSets {
+  uiTest {
+    java {
+      compileClasspath += sourceSets.main.output
+    }
+  }
+}
+
+task uiTest(type: Test) {
+  testClassesDir = sourceSets.uiTest.output.classesDir
+  classpath = sourceSets.uiTest.runtimeClasspath
+  outputs.upToDateWhen { false }
+}
+
+check.dependsOn uiTest
+uiTest.mustRunAfter test
+uiTest.enabled = false
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  uiTestCompile group: 'org.testfx', name: 'testfx-core', version: "${version}"
+  uiTestCompile group: 'org.testfx', name: 'testfx-junit', version: "${version}"
+}


### PR DESCRIPTION
Pull two logically distinct pieces of the gradle build into
script plugins, which made a little bit more sense to me.
In particular, it pulls out the section on UI tests (the
creation of the UI test source set and the TestFX runner)
and the section for the stylechecker into seperate .gradle
files.
