### PR TITLE
Bugfix: Correct results display for unplayed games

### DIFF
--- a/src/main/java/github/ptrteixeira/model/NUDocumentSource.java
+++ b/src/main/java/github/ptrteixeira/model/NUDocumentSource.java
@@ -1,5 +1,7 @@
 package github.ptrteixeira.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
@@ -11,9 +13,11 @@ import java.io.IOException;
  * @author Peter Teixeira
  */
 final class NUDocumentSource implements DocumentSource {
+  private static final Logger logger = LogManager.getLogger();
 
   @Override
   public Document get(String url) throws IOException {
+    logger.debug("Making query to {}", url);
     return Jsoup.connect(url)
         .header("Connection", "keep-alive")
         .header("Accept-Encoding", "gzip, deflate, sdch")

--- a/src/test/resources/test_schedule_unplayed_games.html
+++ b/src/test/resources/test_schedule_unplayed_games.html
@@ -1,0 +1,485 @@
+<!doctype html>
+<html id="ctl00_html" lang="en" class=" wide baseball">
+<head>
+</head>
+<body>
+<main id="ctl00_contentDiv_container" class="contentDiv_container" role="main">
+    <table id='table_dgrdList' width='100%'>
+        <thead>
+        <tr style='display:none'>
+            <th scope="col">Away Logo</th>
+            <th scope="col">Away Team</th>
+            <th scope="col">Away Score</th>
+            <th scope="col">Home Logo</th>
+            <th scope="col">Home Team</th>
+            <th scope="col">Home Score</th>
+            <th scope="col">Conference Game / Doubleheader</th>
+            <th scope="col">Time</th>
+            <th scope="col">Game Location</th>
+            <th scope="col">Notes</th>
+        </tr>
+        </thead>
+        <tbody>
+
+        <tr class='sport_title_row sport_1' data-date='2.19.16'>
+            <td class='table_sport_date_cell' colspan='10'>
+                <div class='sport-section-title'>
+                    <div><span class='game_day'>Friday</span><span
+                            class='game_date'>2.19.16</span><span
+                            class='sport_title'>Baseball</span><span
+                            class='game_count' is_match='0'></span></div>
+                </div>
+            </td>
+        </tr>
+        <tr class='game_row sport_1 school_7 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/bucknell_logo.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class=''>
+                Bucknell
+            </td>
+            <td title='Away Team' class='center border_right '>
+                3
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/James-Madison.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class='won'>
+                James Madison
+            </td>
+            <td title='Home Team' class='center border_right won'>
+                9
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                3:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Harrisonburg, Va.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_10 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/wandm_logo.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class=''>
+                William & Mary
+            </td>
+            <td title='Away Team' class='center border_right '>
+                3
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/UNC-Charlotte.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class='won'>
+                Charlotte
+            </td>
+            <td title='Home Team' class='center border_right won'>
+                7
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                3:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Charlotte, N.C.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_8 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Western-Carolina.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class=''>
+                Western Carolina
+            </td>
+            <td title='Away Team' class='center border_right '>
+                2
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/UNCW_.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class='won'>
+                UNCW
+            </td>
+            <td title='Home Team' class='center border_right won'>
+                15
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                4:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Wilmington, N.C.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_4 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Nebraska.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class='won'>
+                Nebraska
+            </td>
+            <td title='Away Team' class='center border_right won'>
+                4
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Charleston.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class=''>
+                Charleston
+            </td>
+            <td title='Home Team' class='center border_right '>
+                0
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                4:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Charleston, S.C.
+            </td>
+            <td title='Notes and Links'>
+                <a class='gamefile_link' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_2 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Wright-State.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class='won'>
+                Wright State
+            </td>
+            <td title='Away Team' class='center border_right won'>
+                9
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/elon_logo.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class=''>
+                Elon
+            </td>
+            <td title='Home Team' class='center border_right '>
+                7
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                4:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Elon, N.C.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_3 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/o13.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team'>
+                Northeastern
+            </td>
+            <td title='Away Team' class='center border_right'>
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Oklahoma.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class=''>
+                Oklahoma
+            </td>
+            <td title='Home Team' class='center border_right '>
+                2
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                5:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Norman, Okla.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_5 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/U_Delaware.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class='won'>
+                Delaware
+            </td>
+            <td title='Away Team' class='center border_right won'>
+                6
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/StetsonU.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class=''>
+                Stetson
+            </td>
+            <td title='Home Team' class='center border_right '>
+                1
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                6:30 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                DeLand, Fla.
+            </td>
+            <td title='Notes and Links'>
+                <a class='gamefile_link' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_6 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Hofstra-Pride.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class=''>
+                Hofstra
+            </td>
+            <td title='Away Team' class='center border_right '>
+                2
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Texas_AM.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class='won'>
+                Texas A&M
+            </td>
+            <td title='Home Team' class='center border_right won'>
+                5
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                7:35 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                College Station, Texas
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_9 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/Towson_.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class=''>
+                Towson
+            </td>
+            <td title='Away Team' class='center border_right '>
+                5
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/NM-State.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class='won'>
+                New Mexico State
+            </td>
+            <td title='Home Team' class='center border_right won'>
+                8
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                8:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Las Cruces, New Mexico
+            </td>
+            <td title='Notes and Links'>
+                <a class='gamefile_link' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+        <tr class='sport_title_row sport_1' data-date='2.20.16'>
+            <td class='table_sport_date_cell' colspan='10'>
+                <div class='sport-section-title'>
+                    <div><span class='game_day'>Saturday</span><span
+                            class='game_date'>2.20.16</span><span
+                            class='sport_title'>Baseball</span><span class='game_count'
+                                                                     is_match='0'></span>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        <tr class='game_row sport_1 school_7 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/bucknell_logo.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class='won'>
+                Bucknell
+            </td>
+            <td title='Away Team' class='center border_right won'>
+                4
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/James-Madison.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class=''>
+                James Madison
+            </td>
+            <td title='Home Team' class='center border_right '>
+                2
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                1:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Harrisonburg, Va.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+
+
+        <tr class='game_row sport_1 school_10 game_status_O'>
+            <td title='Away Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/wandm_logo.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="away_logo"/>
+            </td>
+            <td title='Away Team' class='won'>
+                William & Mary
+            </td>
+            <td title='Away Team' class='center border_right won'>
+                5
+            </td>
+            <td title='Home Team'>
+                <img class='lazy logo left noprint'
+                     src=''
+                     data-original='/images/logos/UNC-Charlotte.png?mode=crop&amp;width=28&amp;height=28&amp;paddingWidth=5'
+                     alt="home_logo"/>
+            </td>
+            <td title='Home Team' class=''>
+                Charlotte
+            </td>
+            <td title='Home Team' class='center border_right '>
+                1
+            </td>
+            <td class='center border_right'>
+
+            </td>
+            <td title='Game Time' class='border_right'>
+                1:00 p.m.
+            </td>
+            <td title='Game Location' class='border_right'>
+                Charlotte, N.C.
+            </td>
+            <td title='Notes and Links'>
+                <a class='boxscore' target='_blank'>Boxscore</a>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Correct the display for unplayed games. Previously if a game
was not played it would render the result as "L - ", which
is not terribly meaningful. This fixes it to show only the
empty string if the game has no yet been played, as there is
not meaningful information to display.

Closes #10.
