### PR TITLE
Make query on tab change

### DIFF
--- a/src/main/java/github/ptrteixeira/view/MainView.java
+++ b/src/main/java/github/ptrteixeira/view/MainView.java
@@ -53,14 +53,14 @@ public class MainView implements ViewPresenter {
   public void registerTabSwitchCallback(ChangeListener<Tab> tabChangeListener) {
     this.tabPane.getSelectionModel()
         .selectedItemProperty()
-        .addListener(tabChangeListener);
-    this.tabPane.getSelectionModel()
-        .selectedItemProperty()
-        .addListener((observable, oldValue, newValue) ->
-          this.displayType = this.displayType.equals(DisplayType.SCHEDULE) ?
-              DisplayType.STANDINGS :
-              DisplayType.SCHEDULE
-    );
+        .addListener((observable, oldValue, newValue) -> {
+          if (this.displayType == DisplayType.STANDINGS) {
+            this.displayType = DisplayType.SCHEDULE;
+          } else {
+            this.displayType = DisplayType.STANDINGS;
+          }
+          tabChangeListener.changed(observable, oldValue, newValue);
+        });
   }
 
   @Override

--- a/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
+++ b/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
@@ -1,18 +1,5 @@
 package github.ptrteixeira.presenter;
 
-import github.ptrteixeira.model.Match;
-import github.ptrteixeira.model.MockWebScraper;
-import github.ptrteixeira.view.DisplayType;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.scene.input.MouseButton;
-import javafx.scene.input.MouseEvent;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.util.List;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -25,6 +12,19 @@ import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assume.assumeThat;
+
+import github.ptrteixeira.model.Match;
+import github.ptrteixeira.model.MockWebScraper;
+import github.ptrteixeira.view.DisplayType;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
 
 
 /**
@@ -161,5 +161,28 @@ public class MainPresenterTest {
     assertThat(mockWebScraper.standingsRequests.size(),
         is(equalTo(standingsRequests + 1)));
     assertThat(mockWebScraper.standingsRequests.get(0), is("Sport 1"));
+  }
+
+  @Test
+  public void testChangingTabsMakesRequestToModel() {
+    assumeThat(mockViewPresenter.currentDisplayType, is(DisplayType.SCHEDULE));
+    int scheduleRequests = mockWebScraper.scheduleRequests.size();
+    int standingsRequests = mockWebScraper.standingsRequests.size();
+
+
+    mockViewPresenter.changeTab();
+
+    assertThat(mockViewPresenter.currentDisplayType, is(DisplayType.STANDINGS));
+    assertThat(mockWebScraper.standingsRequests.size(),
+        is(equalTo(standingsRequests + 1)));
+    assertThat(mockWebScraper.standingsRequests.get(0), is("Sport 1"));
+
+
+    mockViewPresenter.changeTab();
+
+    assertThat(mockViewPresenter.currentDisplayType, is(DisplayType.SCHEDULE));
+    assertThat(mockWebScraper.scheduleRequests.size(),
+        is(equalTo(scheduleRequests + 1)));
+    assertThat(mockWebScraper.scheduleRequests.get(0), is("Sport 1"));
   }
 }

--- a/src/test/java/github/ptrteixeira/presenter/MockViewPresenter.java
+++ b/src/test/java/github/ptrteixeira/presenter/MockViewPresenter.java
@@ -84,4 +84,14 @@ final class MockViewPresenter implements ViewPresenter {
   public Pane createView() {
     return null;
   }
+
+  void changeTab() {
+    if (this.currentDisplayType == DisplayType.SCHEDULE) {
+      this.currentDisplayType = DisplayType.STANDINGS;
+    } else {
+      this.currentDisplayType = DisplayType.SCHEDULE;
+    }
+
+    this.tabChangeListener.changed(null, null, null);
+  }
 }


### PR DESCRIPTION
The way that it had worked, there were effectively two
sources of truth for the currentDisplayType parameter. The
variable was maintained by the view, but updated by the
presenter. This was not a terribly good pattern, and when
there were inconsistencies between the two bad things
happened, as was the case in this instance. In particular,
it was the case that changing tabs made a request on the tab
that had just been left.

The pattern, quite frankly, is still not terribly good. I
would like to move that variable over to the presenter and
keep it there, as the view doesn't actually care about it.
Currently the view just holds it and keeps it available for
the presenter. This seems to indicate that the variable
should just live in the presenter.
