### PR TITLE
Feature: Add artifacts to circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,6 @@ test:
   post: 
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -wholename "./build/test-results/*.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-    - cp build/reports/style.html $CIRCLE_ARTIFACTS/style.html
+    - mkdir $CIRCLE_ARTIFACTS/style && cp build/reports/checkstyle/*.html -t $CIRCLE_ARTIFACTS/style/
+    - mkdir $CIRCLE_ARTIFACTS/test && cp -r build/reports/test/ -t $CIRCLE_ARTIFACTS/test
 

--- a/gradle/style.gradle
+++ b/gradle/style.gradle
@@ -16,9 +16,6 @@ configurations {
 
 tasks.withType(Checkstyle) {
   config = resources.text.fromArchiveEntry(configurations.checkstyleConfig, 'google_checks.xml')
-  reports {
-    html.destination rootProject.file("build/reports/style.html")
-  }
 }
 
 dependencies {


### PR DESCRIPTION
Add HTML test and style reports to be saved as CircleCI artifacts, allowing them to be retained and viewed after the build has completed.
