### PR TITLE
Move web request to seperate thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script: ./gradlew test
 jdk: oraclejdk8
 cache: 

--- a/src/main/java/github/ptrteixeira/NUSports.java
+++ b/src/main/java/github/ptrteixeira/NUSports.java
@@ -10,6 +10,11 @@ import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author Peter
  * @version 0.1
@@ -20,8 +25,11 @@ public class NUSports extends Application {
   public void start(Stage primaryStage) {
     ViewPresenter view = new MainView();
     WebScraper scraper = new WebScraperFactory().forSite(Site.CAA);
+    ExecutorService executor = new ThreadPoolExecutor(2, 6,
+        500, TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>());
 
-    MainPresenter presenter = new MainPresenter(scraper, view);
+    MainPresenter presenter = new MainPresenter(scraper, view, executor);
 
 
     Scene scene = new Scene(view.createView());
@@ -29,6 +37,10 @@ public class NUSports extends Application {
 
     primaryStage.setTitle("NU Sports");
     primaryStage.setScene(scene);
+    primaryStage.setOnCloseRequest(windowEvent -> {
+      executor.shutdown();
+    });
+
     primaryStage.show();
   }
 

--- a/src/test/java/github/ptrteixeira/presenter/MockViewPresenter.java
+++ b/src/test/java/github/ptrteixeira/presenter/MockViewPresenter.java
@@ -25,6 +25,9 @@ final class MockViewPresenter implements ViewPresenter {
   DisplayType currentDisplayType;
   String errorText;
 
+  MockViewPresenter() {
+    this.currentDisplayType = DisplayType.SCHEDULE;
+  }
 
   @Override
   public void registerTabSwitchCallback(ChangeListener<Tab> tabChangeListener) {


### PR DESCRIPTION
Previously the request to the model (and then, often, to the internet)
was on the same thread as the UI. This made the UI feel very laggy - for
example, clicking to switch tabs would cause the application to pause
while the query ran, and then would only switch tabs after the request
had been responded to.  Now the request is off of the UI thread, so
things like changing tabs is not blocked by making an HTTP request. It
still loads only slowly but there may be nothing to be done about that.
