### PR TITLE
Correct column labels in Standings table

### DIFF
--- a/src/main/java/github/ptrteixeira/view/StandingsTab.java
+++ b/src/main/java/github/ptrteixeira/view/StandingsTab.java
@@ -33,8 +33,8 @@ final class StandingsTab extends AbstractViewTab<Standing> {
     teamName.setCellValueFactory(new PropertyValueFactory<>("teamName"));
     TableColumn<Standing, String> conference = new TableColumn<>("Conference");
     conference.setCellValueFactory(new PropertyValueFactory<>("conference"));
-    TableColumn<Standing, String> overall = new TableColumn<>("Result");
-    overall.setCellValueFactory(new PropertyValueFactory<>("result"));
+    TableColumn<Standing, String> overall = new TableColumn<>("Overall");
+    overall.setCellValueFactory(new PropertyValueFactory<>("overall"));
 
     TableView<Standing> tableView = new TableView<>(this.tableContents);
     tableView.getColumns().add(teamName);


### PR DESCRIPTION
Standings table contained a copy-paste error, specifically in that it
kept one of the columns labeled "Result" instead of the correct value,
"Overall." This corrects both the label and the PropertyValueFactory, so
that the table is correct.

Fixes #23.
