### PR TITLE
Bump Gradle version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 04 16:40:22 EDT 2016
+#Tue Aug 30 12:50:32 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip


### PR DESCRIPTION
Bump Gradle version from 2.13 to 3.0. This change does not take
advantage of any of the changes that come from with Gradle 3, it is just
a version bump.

Closes #21.
