### PR TITLE
Lengthen timeout on fragile test

### DIFF
--- a/src/main/java/github/ptrteixeira/presenter/MainPresenter.java
+++ b/src/main/java/github/ptrteixeira/presenter/MainPresenter.java
@@ -72,7 +72,7 @@ public final class MainPresenter {
     logger.debug("Reload clicked");
     this.scraper.clearCache(this.currentDisplayItem);
 
-    this.changeSelection(this.presenter, this.scraper, this.currentDisplayItem, true);
+    this.changeSelection(this.presenter, this.scraper, this.currentDisplayItem, false);
   }
 
   private void selectionChangeListener(ObservableValue<? extends String> observableValue,
@@ -85,11 +85,11 @@ public final class MainPresenter {
 
   private void changeSelection(ViewPresenter presenter, WebScraper scraper,
                                String currentSelection) {
-    this.changeSelection(presenter, scraper, currentSelection, false);
+    this.changeSelection(presenter, scraper, currentSelection, true);
   }
 
   private void changeSelection(ViewPresenter presenter, WebScraper scraper,
-                               String currentSelection, boolean isRefresh) {
+                               String currentSelection, boolean shouldClear) {
 
     presenter.clearErrorText();
 
@@ -98,9 +98,7 @@ public final class MainPresenter {
       logger.warn("Failed to connect", exn);
       presenter.setErrorText("Failed to load data");
 
-      System.out.println(isRefresh);
-
-      if (!isRefresh) {
+      if (shouldClear) {
         System.out.println("Failed to load stuff");
         presenter.setScheduleContents(Collections.emptyList());
         presenter.setStandingsContents(Collections.emptyList());

--- a/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
+++ b/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
@@ -130,12 +130,13 @@ public class MainPresenterTest {
 
   @Test
   public void testOnFailedReloadContentsAreNotChanged() throws Exception {
+    Thread.sleep(200);
     List<Match> initialContents = mockViewPresenter.scheduleContents;
 
     mockWebScraper.failNextRequest();
     mockViewPresenter.reloadCallback.handle(PRIMARY_MOUSE_CLICK);
 
-    Thread.sleep(400);
+    Thread.sleep(200);
     assertThat(mockViewPresenter.scheduleContents, is(equalTo(initialContents)));
   }
 
@@ -145,7 +146,7 @@ public class MainPresenterTest {
     mockViewPresenter.selectionChange
         .changed(new SimpleStringProperty("Sport 2"), "Sport 1", "Sport 2");
 
-    Thread.sleep(400);
+    Thread.sleep(200);
     assertThat(mockViewPresenter.scheduleContents, is(empty()));
   }
 

--- a/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
+++ b/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
@@ -129,12 +129,13 @@ public class MainPresenterTest {
   }
 
   @Test
-  public void testOnFailedReloadContentsAreNotChanged() {
+  public void testOnFailedReloadContentsAreNotChanged() throws Exception {
     List<Match> initialContents = mockViewPresenter.scheduleContents;
 
     mockWebScraper.failNextRequest();
     mockViewPresenter.reloadCallback.handle(PRIMARY_MOUSE_CLICK);
 
+    Thread.sleep(400);
     assertThat(mockViewPresenter.scheduleContents, is(equalTo(initialContents)));
   }
 
@@ -144,7 +145,7 @@ public class MainPresenterTest {
     mockViewPresenter.selectionChange
         .changed(new SimpleStringProperty("Sport 2"), "Sport 1", "Sport 2");
 
-    Thread.sleep(200);
+    Thread.sleep(400);
     assertThat(mockViewPresenter.scheduleContents, is(empty()));
   }
 


### PR DESCRIPTION
Extend the sleep duration in some of the Presenter tests. It is taking
just a little bit longer than I would like it to for the Presenter
thread to communicate with the UI thread, when a thread gets spun off to
make a request to the model. This will make the test suite run ever so
slightly slower, which is hopefully will not be noticable. More
fundamentally, it doesn't resolve the fundamental problem, which I think
is that is that I have the wrong API here. So that's a problem.
