### PR TITLE
Bikeshedding: Revise test infrastructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,54 @@
-group 'github.PtrTeixeira'
-version '0.1.0'
+buildscript {
+  repositories {
+    mavenCentral()
+  }
 
+  dependencies {
+    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M2'
+  }
+}
+
+plugins {
+  // Language Plugins
+  id 'java'
+
+  // Reporting Plugins
+  id 'project-report'
+  id 'build-dashboard'
+}
+
+apply plugin: 'org.junit.platform.gradle.plugin'
 apply from: "gradle/style.gradle"
 apply from: "gradle/uitest.gradle"
 
+group 'github.PtrTeixeira'
+version '0.1.0'
+
 def versions = [
    jsoup: '1.9.2',
-   junit: '4.12',
+   junit: '5.0.0-M2',
    log4j: '2.6',
    hamcrest: '1.3'
 ]
 
+junitPlatform {
+  includeClassNamePattern '.*Test'
+}
+
 
 // Base plugin
-apply plugin: 'java'
 sourceCompatibility = 1.8
-
-// Reporting Plugins
-apply plugin: 'project-report'
-apply plugin: 'build-dashboard'
-
-tasks.withType(Test) {
-  testLogging {
-    events "passed", "skipped", "failed"
-  }
-}
-
-tasks.withType(Test) {
-  reports.html.destination = file("${reporting.baseDir}/${name}")
-}
 
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  compile group: 'org.jsoup', name: 'jsoup', version: "${versions.jsoup}"
-  compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${versions.log4j}"
+  compile group: 'org.jsoup', name: 'jsoup', version: versions.jsoup
+  compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
 
-  testCompile group: 'junit', name: 'junit', version: "${versions.junit}"
-  testCompile group: 'org.hamcrest', name: "hamcrest-all", version: "${versions.hamcrest}"
+
+  testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: versions.hamcrest
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+  testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 buildscript {
+  ext.kotlin_version = '1.0.3'
+  ext.junit_version = '1.0.0-M2'
+
   repositories {
     mavenCentral()
   }
 
   dependencies {
-    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M2'
+    classpath "org.junit.platform:junit-platform-gradle-plugin:$junit_version"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
 
@@ -18,6 +22,7 @@ plugins {
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'kotlin'
 apply from: "gradle/style.gradle"
 apply from: "gradle/uitest.gradle"
 
@@ -28,12 +33,14 @@ def versions = [
    jsoup: '1.9.2',
    junit: '5.0.0-M2',
    log4j: '2.6',
-   hamcrest: '1.3',
-   assertj: '3.5.2'
+   assertj: '3.5.2',
+   spek: '1.0.77'
 ]
 
 junitPlatform {
-  includeClassNamePattern '.*Test'
+  engines {
+    include 'spek', 'junit-jupiter'
+  }
 }
 
 
@@ -45,10 +52,13 @@ repositories {
 }
 
 dependencies {
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version
   compile group: 'org.jsoup', name: 'jsoup', version: versions.jsoup
   compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
 
   testCompile group: 'org.assertj', name: 'assertj-core', version: versions.assertj
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+  testCompile group: 'org.jetbrains.spek', name: 'spek-api', version: versions.spek
+  testRuntime group: 'org.jetbrains.spek', name: 'spek-junit-platform-engine', version: versions.spek
   testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ def versions = [
    jsoup: '1.9.2',
    junit: '5.0.0-M2',
    log4j: '2.6',
-   hamcrest: '1.3'
+   hamcrest: '1.3',
+   assertj: '3.5.2'
 ]
 
 junitPlatform {
@@ -47,8 +48,7 @@ dependencies {
   compile group: 'org.jsoup', name: 'jsoup', version: versions.jsoup
   compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
 
-
-  testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: versions.hamcrest
+  testCompile group: 'org.assertj', name: 'assertj-core', version: versions.assertj
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
   testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
 }

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ test:
     - ./gradlew check
   post: 
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-    - find . -type f -wholename "./build/test-results/*.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-    - mkdir $CIRCLE_ARTIFACTS/style && cp build/reports/checkstyle/*.html -t $CIRCLE_ARTIFACTS/style/
-    - mkdir $CIRCLE_ARTIFACTS/test && cp -r build/reports/test/ -t $CIRCLE_ARTIFACTS/test
+    - mkdir -p $CIRCLE_ARTIFACTS/{style,test}
+    - find build/test-results -type f -regex ".*[.]xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - cp build/reports/checkstyle/*.html -t $CIRCLE_ARTIFACTS/style/
 

--- a/src/main/java/github/ptrteixeira/presenter/MainPresenter.java
+++ b/src/main/java/github/ptrteixeira/presenter/MainPresenter.java
@@ -99,7 +99,6 @@ public final class MainPresenter {
       presenter.setErrorText("Failed to load data");
 
       if (shouldClear) {
-        System.out.println("Failed to load stuff");
         presenter.setScheduleContents(Collections.emptyList());
         presenter.setStandingsContents(Collections.emptyList());
       }

--- a/src/test/java/github/ptrteixeira/model/NUWebScraperTest.java
+++ b/src/test/java/github/ptrteixeira/model/NUWebScraperTest.java
@@ -11,13 +11,13 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.expectThrows;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.jsoup.Jsoup;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,13 +25,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.junit.rules.ExpectedException;
+//import org.junit.jupiter.api.
+
 /**
  * @author Peter Teixeira
  */
 public class NUWebScraperTest {
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+//  @Rule
+//  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testClearCacheRemovesStatedElementFromCache() throws Exception {
@@ -82,8 +87,7 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    expectedException.expect(NullPointerException.class);
-    webScraper.clearCache(null);
+    expectThrows(NullPointerException.class, () -> webScraper.clearCache(null));
   }
 
   @Test
@@ -110,8 +114,7 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    expectedException.expect(NullPointerException.class);
-    webScraper.getSchedule("key1");
+    assertThrows(NullPointerException.class, () -> webScraper.getSchedule("key1"));
   }
 
   @Test
@@ -151,7 +154,6 @@ public class NUWebScraperTest {
         scheduleCache, documentSource);
 
     ObservableList<Standing> results = webScraper.getStandings("Baseball");
-    System.out.println(results);
 
     assertThat(results, is(not(nullValue())));
     assertThat(results, contains(
@@ -194,8 +196,7 @@ public class NUWebScraperTest {
     WebScraper webScraper = new NUWebScraper(standingsCache,
         scheduleCache, documentSource);
 
-    expectedException.expect(ConnectionFailureException.class);
-    webScraper.getStandings("Baseball");
+    assertThrows(ConnectionFailureException.class, () -> webScraper.getStandings("Baseball"));
   }
 
   @Test
@@ -210,8 +211,7 @@ public class NUWebScraperTest {
     WebScraper webScraper = new NUWebScraper(standingsCache,
         scheduleCache, documentSource);
 
-    expectedException.expect(ConnectionFailureException.class);
-    webScraper.getSchedule("Baseball");
+    assertThrows(ConnectionFailureException.class, () -> webScraper.getSchedule("Baseball"));
   }
 
   @Test

--- a/src/test/java/github/ptrteixeira/model/NUWebScraperTest.java
+++ b/src/test/java/github/ptrteixeira/model/NUWebScraperTest.java
@@ -1,16 +1,5 @@
 package github.ptrteixeira.model;
 
-//import static org.hamcrest.CoreMatchers.equalTo;
-//import static org.hamcrest.CoreMatchers.is;
-//import static org.hamcrest.CoreMatchers.nullValue;
-//import static org.hamcrest.MatcherAssert.assertThat;
-//import static org.hamcrest.Matchers.both;
-//import static org.hamcrest.Matchers.contains;
-//import static org.hamcrest.Matchers.containsInAnyOrder;
-//import static org.hamcrest.Matchers.empty;
-//import static org.hamcrest.Matchers.hasProperty;
-//import static org.hamcrest.Matchers.hasSize;
-//import static org.hamcrest.core.IsNot.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
@@ -145,9 +134,7 @@ public class NUWebScraperTest {
     WebScraper webScraper = new NUWebScraper(standingsCache,
         scheduleCache, documentSource);
 
-    ObservableList<Standing> results = webScraper.getStandings("Baseball");
-
-    assertThat(results)
+    assertThat(webScraper.getStandings("Baseball"))
         .isNotNull()
         .extracting(Standing::getTeamName)
         .containsExactly(

--- a/src/test/java/github/ptrteixeira/model/NUWebScraperTest.java
+++ b/src/test/java/github/ptrteixeira/model/NUWebScraperTest.java
@@ -1,18 +1,19 @@
 package github.ptrteixeira.model;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.expectThrows;
+//import static org.hamcrest.CoreMatchers.equalTo;
+//import static org.hamcrest.CoreMatchers.is;
+//import static org.hamcrest.CoreMatchers.nullValue;
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.hamcrest.Matchers.both;
+//import static org.hamcrest.Matchers.contains;
+//import static org.hamcrest.Matchers.containsInAnyOrder;
+//import static org.hamcrest.Matchers.empty;
+//import static org.hamcrest.Matchers.hasProperty;
+//import static org.hamcrest.Matchers.hasSize;
+//import static org.hamcrest.core.IsNot.not;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.tuple;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -22,22 +23,11 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
-
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.rules.ExpectedException;
-//import org.junit.jupiter.api.
 
 /**
  * @author Peter Teixeira
  */
 public class NUWebScraperTest {
-
-//  @Rule
-//  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testClearCacheRemovesStatedElementFromCache() throws Exception {
     HashMap<String, ObservableList<Standing>> standingsCache = new HashMap<>();
@@ -51,13 +41,13 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    assertThat(standingsCache.keySet(), is(not(empty())));
-    assertThat(scheduleCache.keySet(), is(not(empty())));
+    assertThat(standingsCache).containsOnlyKeys("key1", "key2");
+    assertThat(scheduleCache).containsOnlyKeys("key1", "key2");
 
     webScraper.clearCache("key1");
 
-    assertThat(standingsCache.keySet(), contains("key2"));
-    assertThat(scheduleCache.keySet(), contains("key2"));
+    assertThat(standingsCache).containsOnlyKeys("key2");
+    assertThat(scheduleCache).containsOnlyKeys("key2");
   }
 
   @Test
@@ -71,13 +61,13 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    assertThat(standingsCache.keySet(), is(not(empty())));
-    assertThat(scheduleCache.keySet(), is(not(empty())));
+    assertThat(standingsCache).containsOnlyKeys("key1");
+    assertThat(scheduleCache).containsOnlyKeys("key1");
 
     webScraper.clearCache("key2");
 
-    assertThat(standingsCache.keySet(), contains("key1"));
-    assertThat(scheduleCache.keySet(), contains("key1"));
+    assertThat(standingsCache).containsOnlyKeys("key1");
+    assertThat(scheduleCache).containsOnlyKeys("key1");
   }
 
   @Test
@@ -87,7 +77,8 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    expectThrows(NullPointerException.class, () -> webScraper.clearCache(null));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> webScraper.clearCache(null));
   }
 
   @Test
@@ -103,8 +94,10 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    assertThat(webScraper.getSchedule("key1"), contains(match));
-    assertThat(webScraper.getStandings("key1"), contains(standing));
+    assertThat(webScraper.getSchedule("key1"))
+        .contains(match);
+    assertThat(webScraper.getStandings("key1"))
+        .contains(standing);
   }
 
   @Test
@@ -114,7 +107,8 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, null);
 
-    assertThrows(NullPointerException.class, () -> webScraper.getSchedule("key1"));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> webScraper.getSchedule("key1"));
   }
 
   @Test
@@ -128,17 +122,15 @@ public class NUWebScraperTest {
     WebScraper webScraper = new NUWebScraper(standingsCache,
         scheduleCache, documentSource);
 
-    ObservableList<Match> results = webScraper.getSchedule("Baseball");
-    assertThat(results, is(not(nullValue())));
-    assertThat(results, hasSize(1));
-    assertThat(results, contains(
-        both(hasProperty("opponent", is("Oklahoma")))
-            .and(hasProperty("result", is("W 3 - 2")))));
+    assertThat(webScraper.getSchedule("Baseball"))
+        .isNotNull()
+        .hasSize(1)
+        .extracting(Match::getOpponent, Match::getResult)
+        .containsExactly(tuple("Oklahoma", "W 3 - 2"));
 
-    assertThat(scheduleCache.keySet(), contains("Baseball"));
-    assertThat(scheduleCache.get("Baseball"), hasSize(1));
-
-    assertThat(standingsCache.keySet(), is(empty()));
+    assertThat(scheduleCache).containsOnlyKeys("Baseball");
+    assertThat(scheduleCache.get("Baseball")).hasSize(1);
+    assertThat(standingsCache).isEmpty();
   }
 
   @SuppressWarnings("unchecked")
@@ -155,33 +147,27 @@ public class NUWebScraperTest {
 
     ObservableList<Standing> results = webScraper.getStandings("Baseball");
 
-    assertThat(results, is(not(nullValue())));
-    assertThat(results, contains(
-        hasProperty("teamName", equalTo("UNCW")),
-        hasProperty("teamName", equalTo("William & Mary")),
-        hasProperty("teamName", equalTo("Elon")),
-        hasProperty("teamName", equalTo("James Madison")),
-        hasProperty("teamName", equalTo("Northeastern")),
-        hasProperty("teamName", equalTo("Charleston")),
-        hasProperty("teamName", equalTo("Delaware")),
-        hasProperty("teamName", equalTo("Towson")),
-        hasProperty("teamName", equalTo("Hofstra"))
-    ));
+    assertThat(results)
+        .isNotNull()
+        .extracting(Standing::getTeamName)
+        .containsExactly(
+            "UNCW", "William & Mary", "Elon", "James Madison",
+            "Northeastern", "Charleston", "Delaware", "Towson", "Hofstra");
 
-    assertThat(standingsCache.keySet(), contains("Baseball"));
-    assertThat(standingsCache.get("Baseball"), hasSize(9));
-
-    assertThat(scheduleCache.keySet(), is(empty()));
+    assertThat(standingsCache).containsOnlyKeys("Baseball");
+    assertThat(standingsCache.get("Baseball")).hasSize(9);
+    assertThat(scheduleCache).isEmpty();
   }
 
   @Test
   public void testGetSelectableSports() throws Exception {
     WebScraper webScraper = new NUWebScraper(null, null, null);
 
-    assertThat(webScraper.getSelectableSports(), containsInAnyOrder(
-        "Baseball", "Men's Basketball", "Women's Basketball",
-        "Volleyball", "Men's Soccer", "Women's Soccer"
-    ));
+    assertThat(webScraper.getSelectableSports())
+        .containsExactlyInAnyOrder(
+            "Baseball", "Men's Basketball", "Women's Basketball",
+            "Volleyball", "Men's Soccer", "Women's Soccer"
+        );
   }
 
   @Test
@@ -196,7 +182,8 @@ public class NUWebScraperTest {
     WebScraper webScraper = new NUWebScraper(standingsCache,
         scheduleCache, documentSource);
 
-    assertThrows(ConnectionFailureException.class, () -> webScraper.getStandings("Baseball"));
+    assertThatExceptionOfType(ConnectionFailureException.class)
+        .isThrownBy(() -> webScraper.getStandings("Baseball"));
   }
 
   @Test
@@ -211,7 +198,8 @@ public class NUWebScraperTest {
     WebScraper webScraper = new NUWebScraper(standingsCache,
         scheduleCache, documentSource);
 
-    assertThrows(ConnectionFailureException.class, () -> webScraper.getSchedule("Baseball"));
+    assertThatExceptionOfType(ConnectionFailureException.class)
+        .isThrownBy(() -> webScraper.getSchedule("Baseball"));
   }
 
   @Test
@@ -227,12 +215,9 @@ public class NUWebScraperTest {
 
     WebScraper webScraper = new NUWebScraper(standingsCache, scheduleCache, source);
 
-    List<Match> matches = webScraper.getSchedule("Baseball");
-    List<String> results = matches.stream()
-        .map(Match::getResult)
-        .collect(Collectors.toList());
-
-    assertThat(results, hasSize(1));
-    assertThat(results, contains(""));
+    assertThat(webScraper.getSchedule("Baseball"))
+        .extracting(Match::getResult)
+        .hasSize(1)
+        .containsExactly("");
   }
 }

--- a/src/test/java/github/ptrteixeira/model/WebScraperFactoryTest.java
+++ b/src/test/java/github/ptrteixeira/model/WebScraperFactoryTest.java
@@ -3,30 +3,31 @@ package github.ptrteixeira.model;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Teixeira
  */
 public class WebScraperFactoryTest {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private WebScraperFactory factory;
+
+  @BeforeEach
+  public void setFactory() {
+    this.factory = new WebScraperFactory();
+  }
 
   @Test
   public void forSiteThrowsErrorOnBadArgument() {
-    WebScraperFactory factory = new WebScraperFactory();
-    expectedException.expect(NullPointerException.class);
-    factory.forSite(null);
+    assertThrows(NullPointerException.class, () -> factory.forSite(null));
   }
 
   @Test
   public void forSiteCAACreatesNUWebScraper() {
     // I will be the first to say that this is a bad test.
     // But it is a test, which is a start.
-    WebScraperFactory factory = new WebScraperFactory();
     WebScraper scraper = factory.forSite(Site.CAA);
 
     assertThat(scraper, is(instanceOf(NUWebScraper.class)));

--- a/src/test/java/github/ptrteixeira/model/WebScraperFactoryTest.java
+++ b/src/test/java/github/ptrteixeira/model/WebScraperFactoryTest.java
@@ -1,9 +1,7 @@
 package github.ptrteixeira.model;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +19,8 @@ public class WebScraperFactoryTest {
 
   @Test
   public void forSiteThrowsErrorOnBadArgument() {
-    assertThrows(NullPointerException.class, () -> factory.forSite(null));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> factory.forSite(null));
   }
 
   @Test
@@ -30,6 +29,7 @@ public class WebScraperFactoryTest {
     // But it is a test, which is a start.
     WebScraper scraper = factory.forSite(Site.CAA);
 
-    assertThat(scraper, is(instanceOf(NUWebScraper.class)));
+    assertThat(scraper)
+        .isInstanceOf(NUWebScraper.class);
   }
 }

--- a/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
+++ b/src/test/java/github/ptrteixeira/presenter/MainPresenterTest.java
@@ -11,7 +11,8 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import github.ptrteixeira.model.Match;
 import github.ptrteixeira.model.MockWebScraper;
@@ -21,11 +22,9 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.Stage;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -48,10 +47,7 @@ public class MainPresenterTest {
       false, false, false, false, false, false, false, false, false, false, null
   );
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void launchJavaFX() throws Exception {
     Thread t = new Thread(() -> Application.launch(AsNonApp.class));
     t.setDaemon(true);
@@ -60,7 +56,7 @@ public class MainPresenterTest {
     Thread.sleep(200);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.mockViewPresenter = new MockViewPresenter();
     this.mockWebScraper = new MockWebScraper();
@@ -72,14 +68,13 @@ public class MainPresenterTest {
 
   @Test
   public void testCreateWithNullArgumentsThrowsException() {
-    expectedException.expect(NullPointerException.class);
-    new MainPresenter(null, null, null);
+    assertThrows(NullPointerException.class, () -> new MainPresenter(null, null, null));
   }
 
   @Test
   public void testCreateWithNullArgumentThrowsException() {
-    expectedException.expect(NullPointerException.class);
-    new MainPresenter(new MockWebScraper(), null, null);
+    assertThrows(NullPointerException.class,
+        () -> new MainPresenter(new MockWebScraper(), null, null));
   }
 
   @Test
@@ -94,7 +89,6 @@ public class MainPresenterTest {
 
   @Test
   public void testWillAttemptToPopulateTableWhenLoadPresenterCalled() throws Exception {
-//    Thread.sleep(4000);
     assertThat(mockWebScraper.scheduleRequests, hasSize(greaterThan(0)));
     assertThat(mockViewPresenter.scheduleContents, is(not(empty())));
   }
@@ -156,7 +150,6 @@ public class MainPresenterTest {
 
     mockViewPresenter.reloadCallback.handle(PRIMARY_MOUSE_CLICK);
     Thread.sleep(200);
-    assumeThat(mockViewPresenter.errorText, is(not(isEmptyString())));
 
     mockViewPresenter.reloadCallback.handle(PRIMARY_MOUSE_CLICK);
     Thread.sleep(200);
@@ -189,7 +182,7 @@ public class MainPresenterTest {
 
   @Test
   public void testChangingTabsMakesRequestToModel() {
-    assumeThat(mockViewPresenter.currentDisplayType, is(DisplayType.SCHEDULE));
+    assumeTrue(mockViewPresenter.currentDisplayType == DisplayType.SCHEDULE);
     int scheduleRequests = mockWebScraper.scheduleRequests.size();
     int standingsRequests = mockWebScraper.standingsRequests.size();
 

--- a/src/test/java/github/ptrteixeira/view/DisplayTypeTest.java
+++ b/src/test/java/github/ptrteixeira/view/DisplayTypeTest.java
@@ -3,7 +3,7 @@ package github.ptrteixeira.view;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The point of this class is mostly just for fun.

--- a/src/test/java/github/ptrteixeira/view/DisplayTypeTest.java
+++ b/src/test/java/github/ptrteixeira/view/DisplayTypeTest.java
@@ -1,7 +1,6 @@
 package github.ptrteixeira.view;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasToString;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +17,9 @@ import org.junit.jupiter.api.Test;
 public class DisplayTypeTest {
   @Test
   public void testToStringReturnsExpectedValues() {
-    assertThat(DisplayType.SCHEDULE, hasToString("Schedule"));
-    assertThat(DisplayType.STANDINGS, hasToString("Standings"));
+    assertThat(DisplayType.SCHEDULE)
+        .hasToString("Schedule");
+    assertThat(DisplayType.STANDINGS)
+        .hasToString("Standings");
   }
 }

--- a/src/test/kotlin/github/ptrteixeira/model/NUWebScraperSpec.kt
+++ b/src/test/kotlin/github/ptrteixeira/model/NUWebScraperSpec.kt
@@ -1,0 +1,185 @@
+package github.ptrteixeira.model
+
+import javafx.collections.FXCollections
+import javafx.collections.ObservableList
+import org.assertj.core.api.Assertions.*
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jsoup.Jsoup
+import java.io.File
+import java.io.IOException
+
+/**
+ *
+ */
+class NUWebScraperSpec : Spek({
+  val emptyScheduleCache = emptyMap<String, ObservableList<Match>>()
+  val emptyStandingsCache = emptyMap<String, ObservableList<Standing>>()
+
+  val buildMutableScheduleCache = { mutableMapOf<String, ObservableList<Match>>() }
+  val buildMutableStandingsCache = { mutableMapOf<String, ObservableList<Standing>>() }
+
+  val errorDocumentSource = DocumentSource { throw IOException() }
+
+  describe("clearCache") {
+    val buildStandingsCache = {
+      mutableMapOf(
+          "key1" to FXCollections.emptyObservableList<Standing>(),
+          "key2" to FXCollections.emptyObservableList<Standing>()
+      )
+    }
+    val buildScheduleCache = {
+      mutableMapOf(
+          "key1" to FXCollections.emptyObservableList<Match>(),
+          "key2" to FXCollections.emptyObservableList<Match>()
+      )
+    }
+
+    given("an object in the cache") {
+      it("should remove that object") {
+        val standingsCache = buildStandingsCache()
+        val scheduleCache = buildScheduleCache()
+        val webScraper = NUWebScraper(standingsCache, scheduleCache, null)
+
+        webScraper.clearCache("key1")
+
+        assertThat(standingsCache).containsOnlyKeys("key2")
+        assertThat(scheduleCache).containsOnlyKeys("key2")
+      }
+    }
+    given("an object not in the cache") {
+      it("should do nothing") {
+        val standingsCache = buildStandingsCache()
+        val scheduleCache = buildScheduleCache()
+        val webScraper = NUWebScraper(standingsCache, scheduleCache, null)
+
+        webScraper.clearCache("key3")
+
+        assertThat(standingsCache).containsOnlyKeys("key1", "key2")
+        assertThat(scheduleCache).containsOnlyKeys("key1", "key2")
+      }
+    }
+    given("a null value") {
+      it("should throw a NullPointerException") {
+        val standingsCache = buildStandingsCache()
+        val scheduleCache = buildScheduleCache()
+        val webScraper = NUWebScraper(standingsCache, scheduleCache, null)
+
+        assertThatExceptionOfType(NullPointerException::class.java)
+            .isThrownBy { webScraper.clearCache(null) }
+      }
+    }
+  }
+
+  describe("getSchedule") {
+    val mockSource = DocumentSource { url ->
+      Jsoup.parse(File("src/test/resources/test_schedule.html"), "UTF8", ".")
+    }
+
+    given("a value in the cache") {
+      val standingsCache = emptyStandingsCache
+      val scheduleEntry = FXCollections
+          .singletonObservableList(Match("date", "opponent", "result"))
+      val scheduleCache = mutableMapOf("key1" to scheduleEntry)
+      val webScraper = NUWebScraper(standingsCache, scheduleCache, errorDocumentSource)
+      it("should use the value from the cache") {
+        assertThat(webScraper.getSchedule("key1"))
+            .isEqualTo(scheduleEntry)
+      }
+    }
+    given("a value not in the cache") {
+      val standingsCache = buildMutableStandingsCache()
+      val scheduleCache = buildMutableScheduleCache()
+      val webScraper = NUWebScraper(standingsCache, scheduleCache, mockSource)
+
+      val result = webScraper.getSchedule("Baseball")
+      it("should fetch it from an external source") {
+        assertThat(result)
+            .isNotNull()
+            .hasSize(1)
+            .extracting("opponent", "result")
+            .containsExactly(tuple("Oklahoma", "W 3 - 2"))
+      }
+      it("should store the value in the cache") {
+        assertThat(scheduleCache)
+            .hasSize(1)
+            .containsEntry("Baseball", result)
+        assertThat(standingsCache)
+            .isEmpty()
+      }
+    }
+    context("when an IO error occurs") {
+      it("should throw an ConnectionFailureException") {
+        val webScraper = NUWebScraper(
+            emptyStandingsCache, emptyScheduleCache, errorDocumentSource)
+
+        assertThatExceptionOfType(ConnectionFailureException::class.java)
+            .isThrownBy { webScraper.getSchedule("Baseball") }
+      }
+    }
+  }
+
+  describe("getStandings") {
+    val mockSource = DocumentSource { url ->
+      Jsoup.parse(File("src/test/resources/test_standings.html"), "UTF8", ".");
+    }
+
+    given("a value in the cache") {
+      val standingsEntry = FXCollections
+          .singletonObservableList(Standing("teamName", "conference", "overall"))
+      val standingsCache = mutableMapOf("key1" to standingsEntry)
+      val scheduleCache = emptyScheduleCache
+      val webScraper = NUWebScraper(standingsCache, scheduleCache, errorDocumentSource)
+      it("should use the value from the cache") {
+        assertThat(webScraper.getStandings("key1"))
+            .isEqualTo(standingsEntry)
+      }
+    }
+    given("a value not in the cache") {
+      val standingsCache = buildMutableStandingsCache()
+      val scheduleCache = buildMutableScheduleCache()
+      val webScraper = NUWebScraper(standingsCache, scheduleCache, mockSource)
+
+      val result = webScraper.getStandings("Baseball")
+      it("should fetch it from an external source") {
+        assertThat(result)
+            .isNotNull()
+            .extracting("teamName")
+            .containsExactly(
+                "UNCW", "William & Mary", "Elon", "James Madison",
+                "Northeastern", "Charleston", "Delaware", "Towson", "Hofstra"
+            )
+      }
+      it("should store the value in the cache") {
+        assertThat(standingsCache)
+            .hasSize(1)
+            .containsEntry("Baseball", result)
+        assertThat(scheduleCache).isEmpty()
+      }
+    }
+    context("when an IO error occurs") {
+      it("should throw a ConnectionFailureException") {
+        val webScraper = NUWebScraper(
+            emptyStandingsCache, emptyScheduleCache, errorDocumentSource)
+
+        assertThatExceptionOfType(ConnectionFailureException::class.java)
+            .isThrownBy { webScraper.getStandings("Baseball") }
+      }
+    }
+  }
+
+  describe("getSelectableSports") {
+    it("should return a list of sports supported by this scraper") {
+      val webScraper = NUWebScraper(null, null, null)
+
+      assertThat(webScraper.selectableSports)
+          .containsExactlyInAnyOrder(
+              "Baseball", "Men's Basketball", "Women's Basketball",
+              "Volleyball", "Men's Soccer", "Women's Soccer"
+          )
+    }
+  }
+})


### PR DESCRIPTION
Something I wanted to do as a bit of a trial run was swap from the test infrastructure that I was using with the project, which was JUnit 4 + Hamcrest, to something else. This PR changes all of it (in the test source set. I haven't touched the testUI source set, so that is almost certainly broken. I also haven't been running it, so there's that. Ah, the perils of broken CI.) to Junit 5 + AssertJ, and introduces a single Spek file as a trial run.

To that end, I would like to talk a little bit about my experiences working with these tools. I can offer some pretty strong praise for AssertJ. It is indeed much easier to use in an IDE than Hamcrest was, which is  nice experience. In addition, the version that I was using has much more natural support for lambdas than the version of Hamcrest that I was using, which is also a very nice experience. Finally, it had very powerful tools for filtering and mapping lists/sets/etc under test, which was also a very nice experience. My two objections two it where that there were a small number of places in which it's generic system played poorly with Kotlin's, which isn't really it's fault, and that the `isEqualTo` method took an object rather than a generic type. I can see the reason for it, but I'm not sure that I agree with the decision.

I have no strong feelings for JUnit 5, mostly because I didn't use most of the new features. I do prefer the new before/after annotation styles. Built-in support for lambdas is nice, but I didn't use JUnit assertions, so it didn't matter. The gradle plugin can't generate HTML reports yet, which is a little bit frustrating. Integration with other test systems was a nice feature, and was useful when I added Spek.

I also like Spek. It isn't well-integrated into IDEA, which is funny, as it is nominally a Jetbrains entity. It works pretty much exactly the way RSpec works, which is good, because that is all I was really looking for from it. It will be much nicer once IDE support for it catches up. 

I also looked at KSpec and KotlinTest in the process of this PR. KSpec has the same premise as Spek, but isn't quite as good - in particular, I couldn't get support for nesting or JUnit 5 to play as nicely. I therefore wound up dropping it pretty quickly. Conversely, KotlinTest is really a complement to Spek. In particular, KotlinTest comes with built-in mocking, table-driven tests, and property tests. It also supports a broad range of styles for writing tests. It had the same problems as KSpec, however, namely that it didn't play as nicely with nesting (either in terms of depth or in having multiple sub-tests within a block) or with JUnit 5 (it was running on its own, rather than being registered through the JUnit engine). Having said that, KotlinTest is definitely something that I would look at again.

Closes #6.
