### PR TITLE
Task: Bump dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,11 @@ def versions = [
    junit: '5.0.0-M2',
    log4j: '2.6',
    assertj: '3.5.2',
-   spek: '1.0.77'
+   spek: '1.0.89'
 ]
 
 junitPlatform {
+  platformVersion = "1.0.0-M2"
   engines {
     include 'spek', 'junit-jupiter'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ def versions = [
    jsoup: '1.9.2',
    junit: '5.0.0-M2',
    log4j: '2.6',
-   assertj: '3.5.2',
+   assertj: '3.6.1',
    spek: '1.0.89'
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ group 'com.com.github.PtrTeixeira'
 version '2.0.0'
 
 def versions = [
-   jsoup: '1.9.2',
+   jsoup: '1.10.1',
    junit: '5.0.0-M2',
    log4j: '2.6',
    assertj: '3.6.1',

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ version '2.0.0'
 def versions = [
    jsoup: '1.10.1',
    junit: '5.0.0-M2',
-   log4j: '2.6',
+   log4j: '2.7',
    assertj: '3.6.1',
    spek: '1.0.89'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.4'
+  ext.kotlin_version = '1.0.5-2'
   ext.junit_version = '1.0.0-M2'
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin'
 apply from: "gradle/style.gradle"
 apply from: "gradle/uitest.gradle"
 
-group 'com.com.github.PtrTeixeira'
+group 'com.github.PtrTeixeira'
 version '2.0.0'
 
 def versions = [


### PR DESCRIPTION
Bump a handful of dependency versions. Kicked off because I attempted to update Gradle to 3.2.1, noticed that it broke things (JUnit 5 wasn't playing nicely), then tried to roll back, and had _that_ break things. So I updated all of the things. Except for Gradle and JUnit, which didn't cooperate.