### PR TITLE
Update to Kotlin 1.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.5-3'
+  ext.kotlin_version = '1.0.6'
   ext.junit_version = '1.0.0-M2'
 
   repositories {


### PR DESCRIPTION
Update the used version of Kotlin from 1.0.5-3 to 1.0.6. I should
probably stop updating everytime that a new version of Kotlin comes out,
but its easy enough.

As a side note, I am not going to update to Kotlin 1.1-EAP, because it
does not play with Spek, which is what I'm using for my test framework.
So that's the end of that until 1.1 is officially released / a new
version of Spek is released.