### PR TITLE
Bump Kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 plugins {
   // Language Plugins
   id 'java'
-  id 'nebula.kotlin' version '1.1.2-5.1'
+  id 'nebula.kotlin' version '1.1.3'
 
   // Reporting Plugins
   id 'project-report'
@@ -24,7 +24,7 @@ plugins {
 
   // Annotation Processing
   id 'net.ltgt.apt' version '0.5'
-  id 'org.jetbrains.kotlin.kapt' version '1.1.2-5'
+  id 'org.jetbrains.kotlin.kapt' version '1.1.3'
 
   // Validation plugins
   id 'com.diffplug.gradle.spotless' version '3.4.0'

--- a/src/main/kotlin/com/github/ptrteixeira/nusports/SportsApp.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/nusports/SportsApp.kt
@@ -42,7 +42,7 @@ class SportsApp : App(SportsWorkspace::class) {
             val application: SportsApplication = DaggerSportsApplication.create()
 
             FX.dicontainer = object : DIContainer {
-                override fun <T : Any> getInstance(type: KClass<T>): T {
+                override fun <T: Any> getInstance(type: KClass<T>): T {
                     when (type) {
                         MainController::class -> return application.controller() as T
                         else -> throw IllegalArgumentException()

--- a/src/main/kotlin/com/github/ptrteixeira/nusports/view/Body.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/nusports/view/Body.kt
@@ -59,7 +59,7 @@ class Body : View() {
         }
 
     private fun changeTabs() : ChangeListener<Tab> {
-        return ChangeListener { observable, oldValue, newValue ->
+        return ChangeListener { _, _, newValue ->
             displayType = when (newValue.text) {
                 "Schedule" -> DisplayType.SCHEDULE
                 "Standings" -> DisplayType.STANDINGS
@@ -71,7 +71,7 @@ class Body : View() {
     }
 
     private fun changeSport(): ChangeListener<String> {
-        return ChangeListener { observable, oldValue, newValue ->
+        return ChangeListener { _, _, newValue ->
             currentSelection = newValue
 
             controller.lookup(displayType, currentSelection, clearOnFail = true)

--- a/src/main/kotlin/com/github/ptrteixeira/nusports/view/MainView.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/nusports/view/MainView.kt
@@ -86,7 +86,7 @@ class MainView(private val controller : MainController) : View() {
     }
 
     private fun changeTabs() : ChangeListener<Tab> {
-        return ChangeListener { observable, oldValue, newValue ->
+        return ChangeListener { _, _, newValue ->
             displayType = when (newValue.text) {
                 "Schedule" -> SCHEDULE
                 "Standings" -> STANDINGS
@@ -98,7 +98,7 @@ class MainView(private val controller : MainController) : View() {
     }
 
     private fun changeSport(): ChangeListener<String> {
-        return ChangeListener { observable, oldValue, newValue ->
+        return ChangeListener { _, _, newValue ->
             currentSelection = newValue
 
             controller.lookup(displayType, currentSelection, clearOnFail = true)

--- a/src/test/kotlin/com/github/ptrteixeira/nusports/model/NUWebScraperSpec.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/nusports/model/NUWebScraperSpec.kt
@@ -98,7 +98,7 @@ class NUWebScraperSpec : Spek({
     }
 
     describe("getSchedule") {
-        val mockSource = DocumentSource { url ->
+        val mockSource = DocumentSource {
             Jsoup.parse(File("src/test/resources/test_schedule.html"), "UTF8", ".")
         }
 


### PR DESCRIPTION
Bump Kotlin version 1.1.2 -> 1.1.3. Major pickup from this change is for
incremental annotation processing, which is a very nice bonus for
Dagger2.