### PR TITLE
Add detekt plugin to build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.junit.platform.console.options.Details
+
 buildscript {
   ext.junit_version = '1.0.0-M4'
 
@@ -9,8 +11,6 @@ buildscript {
     classpath "org.junit.platform:junit-platform-gradle-plugin:$junit_version"
   }
 }
-
-import org.junit.platform.console.options.Details
 
 plugins {
   // Language Plugins
@@ -30,9 +30,11 @@ plugins {
 
   // Validation plugins
   id 'com.diffplug.gradle.spotless' version '3.4.0'
+  id 'io.gitlab.arturbosch.detekt' version '1.0.0.M11'
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
+apply from: 'gradle/validation.gradle'
 
 group 'com.github.PtrTeixeira'
 version '3.0.0'
@@ -42,12 +44,10 @@ def versions = [
     junit     : '5.0.0-M4',
     log4j     : '2.8.2',
     assertj   : '3.8.0',
-    spek      : '1.1.2',
     mockito   : '2.8.47',
     dagger    : '2.11',
     tornadofx : '1.7.7',
-    coroutines: '0.16',
-    awaitility: '3.0.0'
+    coroutines: '0.16'
 ]
 
 junitPlatform {
@@ -70,18 +70,9 @@ idea {
   }
 }
 
-spotless {
-  java {
-    removeUnusedImports()
-    googleJavaFormat()
-    licenseHeaderFile 'LICENSE'
-  }
-  kotlin {
-    ktlint()
-    licenseHeaderFile 'LICENSE'
-  }
-  lineEndings 'UNIX'
-}
+
+
+
 
 compileKotlin {
   kotlinOptions {

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,67 @@
+autoCorrect: true
+
+build:
+  warningThreshold: 5
+  failThreshold: 10
+  weights:
+    complexity: 2
+    formatting: 0
+    LongParameterList: 1
+    comments: 0.5
+
+potential-bugs:
+  active: true
+  DuplicateCaseInWhenExpression:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+
+exceptions:
+  active: true
+
+empty-blocks:
+  active: true
+
+complexity:
+  active: true
+  LongMethod:
+    threshold: 20
+  LongParameterList:
+    threshold: 5
+  LargeClass:
+    threshold: 150
+  ComplexMethod:
+    threshold: 10
+  TooManyFunctions:
+    threshold: 10
+  ComplexCondition:
+    threshold: 3
+
+code-smell:
+  active: true
+  FeatureEnvy:
+    threshold: 0.5
+    weight: 0.45
+    base: 0.5
+
+comments:
+  active: true
+  CommentOverPrivateMethod:
+    active: true
+  CommentOverPrivateProperty:
+    active: true
+  NoDocOverPublicClass:
+    active: false
+  NoDocOverPublicMethod:
+    active: false
+
+# *experimental feature*
+# Migration rules can be defined in the same config file or a new one
+migration:
+  active: true
+  imports:
+    # your.package.Class: new.package.or.Class
+    # for example:
+    # io.gitlab.arturbosch.detekt.api.Rule: io.gitlab.arturbosch.detekt.rule.Rule

--- a/gradle/validation.gradle
+++ b/gradle/validation.gradle
@@ -1,0 +1,25 @@
+spotless {
+  java {
+    removeUnusedImports()
+    googleJavaFormat()
+    licenseHeaderFile 'LICENSE'
+  }
+  kotlin {
+    ktlint()
+    licenseHeaderFile 'LICENSE'
+  }
+  lineEndings 'UNIX'
+}
+
+detekt {
+  version = '1.0.0.M11'
+  input = file('src/main/kotlin')
+  config = file("detekt.yml")
+
+  report = file("build/detekt")
+  output = true
+}
+
+check.dependsOn(detektCheck)
+
+


### PR DESCRIPTION
Add the detekt plugin to the build file, because findbugs doesn't work
properly with Kotlin (I don't think). It isn't as complete yet, but it
is still pretty cool.