### PR TITLE
Add loading bar

### DIFF
--- a/src/main/kotlin/com/github/ptrteixeira/nusports/presenter/ViewState.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/nusports/presenter/ViewState.kt
@@ -26,6 +26,7 @@ import com.github.ptrteixeira.nusports.model.ConnectionFailureException
 import com.github.ptrteixeira.nusports.model.Match
 import com.github.ptrteixeira.nusports.model.Standing
 import com.github.ptrteixeira.nusports.model.WebScraper
+import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
@@ -46,7 +47,8 @@ constructor(
     val errorText: SimpleStringProperty = SimpleStringProperty("")
     val selectableSports: List<String> = webScraper.selectableSports
 
-    val selectedSport: SimpleStringProperty = SimpleStringProperty(selectableSports[0])
+    val selectedSport = SimpleStringProperty(selectableSports[0])
+    val isLoading = SimpleBooleanProperty(true)
 
     init {
         selectedSport.onChange { newSelection ->
@@ -57,9 +59,13 @@ constructor(
     }
 
     private fun update(selectedSport: String) {
+        isLoading.set(true)
         launch(context) {
             blockingUpdate(selectedSport)
+        }.invokeOnCompletion {
+            isLoading.set(false)
         }
+
     }
 
     suspend fun blockingUpdate(selectedSport: String) {

--- a/src/main/kotlin/com/github/ptrteixeira/nusports/view/Body.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/nusports/view/Body.kt
@@ -34,11 +34,12 @@ class Body : View() {
     private val sports = viewState.selectableSports
     private val currentSelection = viewState.selectedSport
     private val errorText = viewState.errorText
+    private val loading = viewState.isLoading
 
     private val standingsTable = StandingsTable(viewState.displayedStandings)
     private val scheduleTable = ScheduleTable(viewState.displayedSchedule)
-    private val standingsTab = BodyTab(sports, standingsTable, currentSelection, errorText)
-    private val scheduleTab = BodyTab(sports, scheduleTable, currentSelection, errorText)
+    private val standingsTab = BodyTab(sports, standingsTable, currentSelection, errorText, loading)
+    private val scheduleTab = BodyTab(sports, scheduleTable, currentSelection, errorText, loading)
 
     override val refreshable = SimpleBooleanProperty(true)
     override val savable = SimpleBooleanProperty(false)

--- a/src/main/kotlin/com/github/ptrteixeira/nusports/view/BodyTab.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/nusports/view/BodyTab.kt
@@ -21,23 +21,27 @@
  */
 package com.github.ptrteixeira.nusports.view
 
+import javafx.beans.property.BooleanProperty
 import javafx.beans.property.StringProperty
 import javafx.scene.paint.Color
 import tornadofx.View
 import tornadofx.borderpane
+import tornadofx.bottom
 import tornadofx.center
 import tornadofx.combobox
 import tornadofx.left
+import tornadofx.progressbar
 import tornadofx.text
 import tornadofx.vbox
+import tornadofx.visibleWhen
 
 class BodyTab(
     private val sports: List<String>,
     private val centerContents: View,
     selectedItem: StringProperty,
-    errorText: StringProperty
+    errorText: StringProperty,
+    isLoading: BooleanProperty
 ) : View() {
-
     override val root = borderpane {
         left {
             vbox {
@@ -54,6 +58,12 @@ class BodyTab(
 
         center {
             add(centerContents)
+        }
+
+        bottom {
+            progressbar {
+                visibleWhen(isLoading)
+            }
         }
     }
 }


### PR DESCRIPTION
Add a loading bar to the bottom corner of the application when the UI is
loading new data into the table. This makes the UI much more obviously
responsive, rather than just having it appear to not do anything and
suddenly load more things into the table. I would prefer it if the table
went away while loading; will look into it.