### PR TITLE
Add application plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ plugins {
   // Validation plugins
   id 'com.diffplug.gradle.spotless' version '3.4.0'
   id 'io.gitlab.arturbosch.detekt' version '1.0.0.M11'
+
+  // Application
+  id 'application'
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
@@ -70,9 +73,9 @@ idea {
   }
 }
 
-
-
-
+distTar {
+  compression = Compression.GZIP
+}
 
 compileKotlin {
   kotlinOptions {
@@ -91,8 +94,8 @@ kapt {
   correctErrorTypes = true
 }
 
-// Base plugin
 sourceCompatibility = 1.8
+mainClassName = 'com.github.ptrteixeira.nusports.SportsApp'
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
Adds the application plugin. Now the project can be run from the command
line - and even better, started from a shell script - which means that
you don't need to boot up Intellij to run the darn thing.