### PR TITLE
Bump to Kotlin 1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
-import org.junit.platform.console.options.Details
-
 buildscript {
-  ext.junit_version = '1.0.1'
+  ext.junit_version = '1.0.2'
 
   repositories {
     mavenCentral()
@@ -15,7 +13,7 @@ buildscript {
 plugins {
   // Language Plugins
   id 'java'
-  id 'nebula.kotlin' version '1.1.51'
+  id 'nebula.kotlin' version '1.2.0'
 
   // Reporting Plugins
   id 'project-report'
@@ -26,11 +24,9 @@ plugins {
 
   // Annotation Processing
   id 'net.ltgt.apt' version '0.5'
-  id 'org.jetbrains.kotlin.kapt' version '1.1.51'
 
   // Validation plugins
-  id 'com.diffplug.gradle.spotless' version '3.4.0'
-  id 'io.gitlab.arturbosch.detekt' version '1.0.0.M11'
+  id 'com.diffplug.gradle.spotless' version '3.6.0'
 
   // Application
   id 'application'
@@ -38,19 +34,20 @@ plugins {
 
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply from: 'gradle/validation.gradle'
+apply plugin: 'kotlin-kapt'
 
 group 'com.github.PtrTeixeira'
-version '3.1.0'
+version '3.1.1'
 
 def versions = [
-    jsoup     : '1.10.3',
-    junit     : '5.0.1',
-    log4j     : '2.8.2',
+    jsoup     : '1.11.1',
+    junit     : '5.0.2',
+    log4j     : '2.9.1',
     assertj   : '3.8.0',
-    mockito   : '2.8.47',
-    dagger    : '2.11',
-    tornadofx : '1.7.11',
-    coroutines: '0.19'
+    mockito   : '2.11.0',
+    dagger    : '2.12',
+    tornadofx : '1.7.12',
+    coroutines: '0.19.3'
 ]
 
 junitPlatform {
@@ -59,7 +56,6 @@ junitPlatform {
       include 'spek', 'junit-jupiter'
     }
   }
-  details = Details.TREE
 }
 
 // Because Intellij plays poorly with Dagger
@@ -78,7 +74,7 @@ distTar {
 
 compileKotlin {
   kotlinOptions {
-    apiVersion = "1.1"
+    apiVersion = "1.2"
     jvmTarget = '1.8'
   }
 }
@@ -107,6 +103,8 @@ dependencies {
   compile group: 'no.tornado', name: 'tornadofx', version: versions.tornadofx
   compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: versions.coroutines
   compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-javafx', version: versions.coroutines
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'
 
   compile group: 'com.google.dagger', name: 'dagger', version: versions.dagger
   kapt group: 'com.google.dagger', name: 'dagger-compiler', version: versions.dagger

--- a/gradle/validation.gradle
+++ b/gradle/validation.gradle
@@ -11,15 +11,3 @@ spotless {
   lineEndings 'UNIX'
 }
 
-detekt {
-  version = '1.0.0.M11'
-  input = file('src/main/kotlin')
-  config = file("detekt.yml")
-
-  report = file("build/detekt")
-  output = true
-}
-
-check.dependsOn(detektCheck)
-
-


### PR DESCRIPTION
Several version bumps, but the most important one is the change to
Kotlin 1.2. I did also drop Detekt, bump a bugfix JUnit, and bump some
actual dependency versions.